### PR TITLE
Fix log payload json tag typo

### DIFF
--- a/broker-service/cmd/api/handlers.go
+++ b/broker-service/cmd/api/handlers.go
@@ -12,7 +12,7 @@ import (
 type RequestPayload struct {
 	Action string      `json:"action"`
 	Auth   AuthPayload `json:"auth,omitempty"`
-	Log    LogPayload  `json:"log,imotempty"`
+	Log    LogPayload  `json:"log,omitempty"`
 	Mail   MailPayload `json:"mail,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- fix misspelled json tag for Log field in broker request payload

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68ac88220a0c833086e92fff464d3a52