### PR TITLE
Ensure broker test uses valid URL

### DIFF
--- a/front-end/cmd/web/main.go
+++ b/front-end/cmd/web/main.go
@@ -49,8 +49,11 @@ func render(w http.ResponseWriter, t string) {
 		BrokerUrl string
 	}
 
-	//data.BrokerUrl = os.Getenv("BROKER_URL")
-	data.BrokerUrl = os.Getenv("BROKER_URL")
+	brokerURL := os.Getenv("BROKER_URL")
+	if brokerURL == "" {
+		brokerURL = "http://localhost:8080"
+	}
+	data.BrokerUrl = brokerURL
 
 	if err := tmpl.Execute(w, data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/front-end/cmd/web/templates/test.page.gohtml
+++ b/front-end/cmd/web/templates/test.page.gohtml
@@ -64,7 +64,7 @@
             headers: headers,
         }
 
-        fetch({{print .BrokerUrl "/handle"}}, body)
+        fetch("{{print .BrokerUrl "/handle"}}", body)
         .then((response) => response.json())
         .then((data) => {
             sent.innerHTML = JSON.stringify(payload, undefined, 4);
@@ -99,7 +99,7 @@
             body: JSON.stringify(payload),
             headers: headers,
         }
-        fetch({{print .BrokerUrl "/handle"}}, body)
+        fetch("{{print .BrokerUrl "/handle"}}", body)
         .then((response) => response.json())
         .then((data) => {
             sent.innerHTML = JSON.stringify(payload, undefined, 4);
@@ -135,7 +135,7 @@
             headers: headers,
         }
 
-        fetch({{print .BrokerUrl "/handle"}}, body)
+        fetch("{{print .BrokerUrl "/handle"}}", body)
         .then((response) => response.json())
         .then((data) => {
             sent.innerHTML = JSON.stringify(payload, undefined, 4);
@@ -157,7 +157,7 @@
             method: 'POST',
         }
 
-        fetch({{.BrokerUrl}}, body)
+        fetch("{{.BrokerUrl}}", body)
         .then((response) => response.json())
         .then((data) => {
             sent.innerHTML ="empty post request";


### PR DESCRIPTION
## Summary
- Escape broker URL in test page JavaScript to ensure `fetch` receives a string
- Provide a default `BROKER_URL` in the front-end service when the environment variable is missing

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68ac9013d18c83309fabce8b28eb3b25